### PR TITLE
do not restrict sysdeps to selfowned

### DIFF
--- a/routes/repos.js
+++ b/routes/repos.js
@@ -828,7 +828,7 @@ router.get("/:user/stats/revdeps", function(req, res, next) {
 
 router.get("/:user/stats/sysdeps", function(req, res, next) {
   var cursor = packages.aggregate([
-    {$match: qf({_user: req.params.user, _type: 'src', '_selfowned' : true, '_builder.sysdeps': {$exists: true}})},
+    {$match: qf({_user: req.params.user, _type: 'src', '_builder.sysdeps': {$exists: true}})},
     {$unwind: '$_builder.sysdeps'},
     {$group: {
       _id : '$_builder.sysdeps.name',


### PR DESCRIPTION
We build our lessons on GitHub actions and use the sysdeps API to query the system requirements for our dependencies and speed up the installation process (as opposed to using `remotes::system_dependencies()`, which can take a hot minute):

https://github.com/carpentries/actions/blob/92005c53a8518a8160fb873aef77f5fed9aa9f84/setup-sandpaper/action.yaml#L46-L49

https://github.com/r-universe-org/cranlike-server/commit/6802011ff043108d6a60b5a2f61f071cfdd103f0 broke this pattern for us by returning absolutely nothing because the packages we author do not contain any compiled code.
