### PR TITLE
Flattening step 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 3000
 ENV CRANLIKE_MONGODB_SERVER="mongo" \
     VCAP_APP_HOST="0.0.0.0"
 
-RUN mkdir /app && cd /app && npm install cranlike@0.16.10
+RUN mkdir /app && cd /app && npm install cranlike@0.16.11
 
 WORKDIR /app/node_modules/cranlike
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cranlike",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "description": "High-performance R package server",
   "author": "Jeroen Ooms <jeroen@berkeley.edu>",
   "license": "MIT",

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -341,7 +341,7 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
   var filename = get_filename(package, version, type, builder.distro);
   crandb_store_file(req, md5, filename).then(function(filedata){
     if(type == 'src'){
-      var p1 = packages.find({_type: 'src', _registered: true, '_rundeps': package}).count();
+      var p1 = packages.find({_type: 'src', _registered: true, '_contents.rundeps': package}).count();
       var p2 = extract_json_metadata(bucket.openDownloadStream(md5), package);
       return Promise.all([filedata, p1, p2]);
     } else {
@@ -428,7 +428,7 @@ router.post('/:user/packages/:package/:version/:type', upload.fields([{ name: 'f
   var stream = fs.createReadStream(filepath);
   crandb_store_file(stream, md5, filename).then(function(filedata){
     if(type == 'src'){
-      var p1 = packages.find({_type: 'src', _registered: true, '_rundeps': package}).count();
+      var p1 = packages.find({_type: 'src', _registered: true, '_contents.rundeps': package}).count();
       var p2 = extract_json_metadata(bucket.openDownloadStream(md5), package);
       return Promise.all([filedata, p1, p2]);
     } else {

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -503,7 +503,7 @@ router.patch('/:user/packages/:package/:version/:type', function(req, res, next)
         return;
       }
     }
-    var run_url = builder._url;
+    var run_url = doc._url;
     if(!run_url) {
       throw `Failed to find _url in ${package} ${version}`;
     }

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -359,6 +359,7 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
       description['_filesize'] = filedata.length;
       description['_created'] = get_created(description);
       description['_published'] = new Date();
+      description['_builder'] = builder; //TODO: remove
       description['_owner'] = get_repo_owner(description);
       add_meta_fields(description, builder);
       merge_dependencies(description);
@@ -367,6 +368,7 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
       description['_registered'] = builder.registered !== "false";
       if(type == "src"){
         description['_usedby'] = metadata[1];
+        description['_contents'] = metadata[2]; //TODO: remove
         add_meta_fields(description, metadata[2]); //contents.json
         description['_score'] = calculate_score(description);
         description['_indexed'] = is_indexed(description);
@@ -399,6 +401,7 @@ router.post('/:user/packages/:package/:version/failure', upload.none(), function
   var maintainer = `${builder.maintainer.name} <${builder.maintainer.email}>`;
   var query = {_type : 'failure', _user : user, Package : package};
   var description = {...query, Version: version, Maintainer: maintainer, _published: new Date()};
+  description['_builder'] = builder; //TODO: remove
   add_meta_fields(description, builder);
   description['_created'] = new Date();
   description['_owner'] = get_repo_owner(description);
@@ -442,6 +445,7 @@ router.post('/:user/packages/:package/:version/:type', upload.fields([{ name: 'f
       description['_filesize'] = filedata.length;
       description['_created'] = get_created(description);
       description['_published'] = new Date();
+      description['_builder'] = builder; //TODO: remove
       description['_owner'] = get_repo_owner(description);
       add_meta_fields(description, builder);
       merge_dependencies(description);
@@ -450,6 +454,7 @@ router.post('/:user/packages/:package/:version/:type', upload.fields([{ name: 'f
       description['_registered'] = builder.registered !== "false";
       if(type == "src"){
         description['_usedby'] = metadata[1];
+        description['_contents'] = metadata[2]; //TODO: remove
         add_meta_fields(description, metadata[2]); //contents.json
         description['_score'] = calculate_score(description);
         description['_indexed'] = is_indexed(description);
@@ -498,7 +503,6 @@ router.patch('/:user/packages/:package/:version/:type', function(req, res, next)
         return;
       }
     }
-    //var builder = doc['_builder'];
     var run_url = builder._url;
     if(!run_url) {
       throw `Failed to find _url in ${package} ${version}`;

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -209,6 +209,12 @@ function validate_description(data, package, version, type){
     //Built.Platform is missing for binary pkgs without copiled code
     throw 'MacOS Binary package has unexpected Platform:' + data.Built.Platform;
   }
+  if(!data._commit || !data._commit.id){
+    throw 'No commit data found in builder metadata';
+  }
+  if(!data._maintainer || !data._maintainer.email){
+    throw 'No maintainer data found in builder metadata';
+  }
 }
 
 function filter_keys(x, regex){

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -227,21 +227,6 @@ function from_base64_gzip(str){
 
 function parse_builder_fields(x){
   var builder = filter_keys(x, /^builder-/gi);
-  if(builder.sysdeps){
-    builder.sysdeps = from_base64_gzip(builder.sysdeps);
-  }
-  if(builder.vignettes){
-    builder.vignettes = from_base64_gzip(builder.vignettes);
-  }
-  if(builder.gitstats){
-    builder.gitstats = from_base64_gzip(builder.gitstats);
-  }
-  if(builder.rundeps){
-    builder.rundeps = from_base64_gzip(builder.rundeps);
-  }
-  if(builder.assets){
-    builder.assets = from_base64_gzip(builder.assets);
-  }
   builder.commit = from_base64_gzip(builder.commit) || {};
   builder.maintainer = from_base64_gzip(builder.maintainer) || {};
   return builder;


### PR DESCRIPTION
This flattens the `builder` and `content` fields on submission. We also keep the `_builder` and `_content` fields for now because that is what we use everywhere else.