### PR TITLE
Convert to ESM module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 package-lock.json
+.Rproj.user

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache bash tini
 
 EXPOSE 3000
 
-RUN mkdir /app && cd /app && npm install cranlike@0.22.2
+RUN mkdir /app && cd /app && npm install cranlike@0.22.3
 
 WORKDIR /app/node_modules/cranlike
 

--- a/app.js
+++ b/app.js
@@ -1,21 +1,20 @@
 /* Express template stuff */
-var createError = require('http-errors');
-var express = require('express');
-var cors = require('cors')
-var path = require('path');
-var logger = require('morgan');
+import createError from 'http-errors';
+import logger from 'morgan';
+import express from 'express';
+import cors from 'cors';
 
 /* Routers */
-var cdnRouter = require('./routes/cdn');
-var packagesRouter = require('./routes/packages');
-var reposRouter = require('./routes/repos');
-var searchRouter = require('./routes/search');
-var badgesRouter = require('./routes/badges');
-var feedsRouter = require('./routes/feeds');
-var sharedRouter = require('./routes/shared');
-var snapshotRouter = require('./routes/snapshot');
-var v2Router = require('./routes/v2');
-var webrRouter = require('./routes/webr');
+import cdnRouter from './routes/cdn.js';
+import packagesRouter from './routes/packages.js';
+import reposRouter from './routes/repos.js';
+import searchRouter from './routes/search.js';
+import badgesRouter from './routes/badges.js';
+import feedsRouter from './routes/feeds.js';
+import sharedRouter from './routes/shared.js';
+import snapshotRouter from './routes/snapshot.js';
+import v2Router from './routes/v2.js';
+import webrRouter from './routes/webr.js';
 
 /* Start App */
 var app = express();
@@ -24,14 +23,14 @@ var app = express();
 app.set('json spaces', 2)
 
 // view engine setup
-app.set('views', path.join(__dirname, 'views'));
+app.set('views', 'views');
 app.set('view engine', 'pug');
 
 app.use(cors())
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
-app.use('/assets', express.static(path.join(__dirname, 'assets')));
+app.use('/assets', express.static('assets'));
 app.use('/', cdnRouter);
 app.use('/', packagesRouter);
 app.use('/', reposRouter);
@@ -58,4 +57,4 @@ app.use(function(err, req, res, next) {
   res.render('error');
 });
 
-module.exports = app;
+export default app;

--- a/bin/www
+++ b/bin/www
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
-import app from '../app.js';
 import http from 'node:http';
-import dbcon from '../src/db.js';
+import app from '../app.js';
 
 /* Last resort error handler, that should never happen but somehow it sometimes does.
    We quit because in a case of OOM/DOS, a restart may just be the best solution.
@@ -13,55 +12,20 @@ process.on('uncaughtException', function(err) {
   process.exit(1);
 });
 
-/**
- * Get port from environment and store in Express.
- */
-
-var port = normalizePort(process.env.PORT || '3000');
+var port = parseInt(process.env.PORT || '3000');
 app.set('port', port);
 
-/**
- * Create HTTP server.
- */
-
 var server = http.createServer(app);
+server.listen(port);
+server.on('error', onError);
+server.on('listening', onListening);
 
 /**
- * Listen on provided port, on all network interfaces.
+ * This must be greater than the nginx timeout (60s)
+ * https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/
  */
-
-dbcon.then(function(){
-  server.listen(port);
-  server.on('error', onError);
-  server.on('listening', onListening);
-
-  /**
-   * This must be greater than the nginx timeout (60s)
-   * https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/
-   */
-  server.keepAliveTimeout = 62*1000;
-  server.headersTimeout = 65*1000;
-});
-
-/**
- * Normalize a port into a number, string, or false.
- */
-
-function normalizePort(val) {
-  var port = parseInt(val, 10);
-
-  if (isNaN(port)) {
-    // named pipe
-    return val;
-  }
-
-  if (port >= 0) {
-    // port number
-    return port;
-  }
-
-  return false;
-}
+server.keepAliveTimeout = 62*1000;
+server.headersTimeout = 65*1000;
 
 /**
  * Event listener for HTTP server "error" event.

--- a/bin/www
+++ b/bin/www
@@ -1,13 +1,8 @@
-#!/usr/bin/env node
+#!/usr/bin/env
 
-/**
- * Module dependencies.
- */
-
-var app = require('../app');
-var debug = require('debug')('cranlike:server');
-var http = require('http');
-var dbcon = require('../src/db');
+import app from '../app.js';
+import http from 'node:http';
+import dbcon from '../src/db.js';
 
 /* Last resort error handler, that should never happen but somehow it sometimes does.
    We quit because in a case of OOM/DOS, a restart may just be the best solution.

--- a/bin/www
+++ b/bin/www
@@ -1,4 +1,4 @@
-#!/usr/bin/env
+#!/usr/bin/env node
 
 import app from '../app.js';
 import http from 'node:http';

--- a/deno-local.sh
+++ b/deno-local.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# npm install
+#trap 'kill $(jobs -p)' EXIT
+if [ -f "/opt/homebrew/etc/mongod.conf" ]; then
+mongoconfig="/opt/homebrew/etc/mongod.conf"
+else
+mongoconfig="/usr/local/etc/mongod.conf"
+fi
+DEBUG=cranlike:* mongod --config $mongoconfig & sleep 2 & deno --allow-net --allow-sys --allow-write --allow-env --allow-read ./bin/www

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cranlike",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "type": "module",
   "description": "High-performance R package server",
   "author": "Jeroen Ooms <jeroen@berkeley.edu>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cranlike",
   "version": "0.22.2",
+  "type": "module",
   "description": "High-performance R package server",
   "author": "Jeroen Ooms <jeroen@berkeley.edu>",
   "license": "MIT",

--- a/routes/badges.js
+++ b/routes/badges.js
@@ -1,8 +1,9 @@
-const express = require('express');
-const createError = require('http-errors');
-const badgen = require('badgen');
+import express from 'express';
+import createError from 'http-errors';
+import badgen from 'badgen';
+import {test_if_universe_exists, get_registry_info} from '../src/tools.js';
+
 const router = express.Router();
-const tools = require("../src/tools.js");
 
 function error_cb(status, next) {
   return function(err){
@@ -28,7 +29,7 @@ router.get('/:user/badges/::meta', function(req, res, next) {
     style: req.query.style,
     scale: req.query.scale
   };
-  tools.test_if_universe_exists(user).then(function(x){
+  test_if_universe_exists(user).then(function(x){
     var meta = req.params.meta;
     if(!x) return res.type('text/plain').status(404).send('No universe for user: ' + user);
     if(meta == 'name'){
@@ -51,7 +52,7 @@ router.get('/:user/badges/::meta', function(req, res, next) {
       });
     } else if(meta == 'registry'){
       /* This badge mimics https://github.com/r-universe/jeroen/actions/workflows/sync.yml/badge.svg (which is super slow) */
-        return tools.get_registry_info(user).then(function(data){
+        return get_registry_info(user).then(function(data){
           if(data && data.workflow_runs && data.workflow_runs.length){
             const success = data.workflow_runs[0].conclusion == 'success';
             const linkto = 'https://github.com/r-universe/' + user + '/actions/workflows/sync.yml';
@@ -71,7 +72,7 @@ router.get('/:user/badges/::meta', function(req, res, next) {
 
 router.get('/:user/badges/:package', function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
+  var pkg = req.params.package;
   var color = req.query.color;
   var badge = {
     label: 'r-universe',
@@ -81,13 +82,13 @@ router.get('/:user/badges/:package', function(req, res, next) {
     scale: req.query.scale
   };
   //badge.icon = 'data:image/svg+xml;base64,...';
-  packages.distinct('Version', {_user : user, Package : package, _type: 'src', '_registered' : true}).then(function(x){
+  packages.distinct('Version', {_user : user, Package : pkg, _type: 'src', '_registered' : true}).then(function(x){
     if(x.length){
       badge.status = x.join("|");
       badge.color = color || 'green';
     }
-    send_badge(badge, user, res, `https://${user}.r-universe.dev/${package}`);
+    send_badge(badge, user, res, `https://${user}.r-universe.dev/${pkg}`);
   }).catch(error_cb(400, next));
 });
 
-module.exports = router;
+export default router;

--- a/routes/badges.js
+++ b/routes/badges.js
@@ -2,6 +2,7 @@ import express from 'express';
 import createError from 'http-errors';
 import badgen from 'badgen';
 import {test_if_universe_exists, get_registry_info} from '../src/tools.js';
+import {packages} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/cdn.js
+++ b/routes/cdn.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import createError from 'http-errors';
+import {bucket} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/cdn.js
+++ b/routes/cdn.js
@@ -1,5 +1,6 @@
-const express = require('express');
-const createError = require('http-errors');
+import express from 'express';
+import createError from 'http-errors';
+
 const router = express.Router();
 
 /* Error generator */
@@ -41,4 +42,4 @@ router.get("/cdn/", function(req, res, next) {
   next(createError(400, "Invalid request"));
 });
 
-module.exports = router;
+export default router;

--- a/routes/feeds.js
+++ b/routes/feeds.js
@@ -1,11 +1,10 @@
-const express = require('express');
-const createError = require('http-errors');
-const xmlbuilder = require('xmlbuilder');
+import express from 'express';
+import createError from 'http-errors';
+import xmlbuilder from 'xmlbuilder';
+import {qf, test_if_universe_exists} from '../src/tools.js';
+
 const router = express.Router();
-const tools = require("../src/tools.js");
-const { version } = require('../package.json');
 const opts = { pretty: false, allowEmpty: false };
-const qf = tools.qf;
 
 function error_cb(status, next) {
   return function(err){
@@ -18,7 +17,7 @@ router.get('/:user/feed.xml', function(req, res, next) {
   var user = req.params.user;
   const query = qf({_user: user, _registered: true, _type: {$in: ['src', 'failure']}}, true);
   const limit = parseInt(req.query.limit) || 50;
-  tools.test_if_universe_exists(user).then(function(x){
+  test_if_universe_exists(user).then(function(x){
     if(!x) return res.type('text/plain').status(404).send('No universe for user: ' + user);
     var cursor = packages.find(query)
       .sort({'_commit.time' : -1})
@@ -65,7 +64,7 @@ router.get('/:user/feed.xml', function(req, res, next) {
           .ele('title', title).up()
           .ele('link', repo).up()
           .ele('description', 'Package updated in ' + user).up()
-          .ele('generator', 'cranlike-server ' + version).up()
+          .ele('generator', 'cranlike-server ').up()
           .ele('image')
             .ele('url', 'https://github.com/' + user + '.png?size=400').up()
             .ele('title', title).up()
@@ -155,4 +154,4 @@ function convert_maintainer(str){
   return str;
 }
 
-module.exports = router;
+export default router;

--- a/routes/feeds.js
+++ b/routes/feeds.js
@@ -2,6 +2,7 @@ import express from 'express';
 import createError from 'http-errors';
 import xmlbuilder from 'xmlbuilder';
 import {qf, test_if_universe_exists} from '../src/tools.js';
+import {packages} from '../src/db.js';
 
 const router = express.Router();
 const opts = { pretty: false, allowEmpty: false };

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -11,6 +11,7 @@ import crypto from 'node:crypto';
 import rconstants from 'r-constants';
 import {match_macos_arch, trigger_rebuild, trigger_recheck, get_submodule_hash, extract_multi_files} from '../src/tools.js';
 import {packages, bucket, chunks, db} from '../src/db.js';
+import {Buffer} from "node:buffer";
 
 /* Local variables */
 const multerstore = multer({ dest: '/tmp/' });

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -1,22 +1,19 @@
 /* Packages */
-const express = require('express');
-const createError = require('http-errors');
-const multer  = require('multer')
-const md5file = require('md5-file');
-const rdesc = require('rdesc-parser');
-const fs = require('fs');
-const zlib = require('zlib');
-const tar = require('tar-stream');
-const crypto = require('node:crypto')
-const dependency_types = require('r-constants').dependency_types;
+import express from 'express';
+import createError from 'http-errors';
+import multer from 'multer';
+import md5file from 'md5-file';
+import rdesc from 'rdesc-parser';
+import fs from 'node:fs';
+import zlib from 'node:zlib';
+import tar from 'tar-stream';
+import crypto from 'node:crypto';
+import rconstants from 'r-constants';
+import {match_macos_arch, trigger_rebuild, trigger_recheck, get_submodule_hash, extract_multi_files} from '../src/tools.js';
 
 /* Local variables */
 const multerstore = multer({ dest: '/tmp/' });
 const router = express.Router();
-
-/* Local code */
-const tools = require("../src/tools.js");
-const match_macos_arch = tools.match_macos_arch;
 
 /* Error generator */
 function error_cb(status, next) {
@@ -65,8 +62,7 @@ router.get('/:user/packages/:package', function(req, res, next) {
 
 router.get('/:user/packages/:package/:version?/:type?/:built?', function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
-  var query = {_user : user, Package : package};
+  var query = {_user : user, Package : req.params.package};
   if(req.params.version && req.params.version != "any")
     query.Version = req.params.version;
   if(req.params.type)
@@ -78,7 +74,6 @@ router.get('/:user/packages/:package/:version?/:type?/:built?', function(req, re
 
 router.delete('/:user/packages/:package/:version?/:type?/:built?', function(req, res, next){
   var user = req.params.user;
-  var package = req.params.package;
   var query = {_user: req.params.user, Package: req.params.package};
   if(req.params.version && req.params.version != "any")
     query.Version = req.params.version
@@ -150,7 +145,7 @@ function crandb_store_file(stream, key, filename){
   });
 }
 
-function get_filename(package, version, type, distro){
+function get_filename(pkgname, version, type, distro){
   const ext = {
     src : '.tar.gz',
     mac : '.tgz',
@@ -158,14 +153,14 @@ function get_filename(package, version, type, distro){
     wasm: '.tgz',
     linux: `-${distro || "linux"}.tar.gz`
   }
-  return package + "_" + version + ext[type];
+  return pkgname + "_" + version + ext[type];
 }
 
-function validate_description(data, package, version, type){
+function validate_description(data, pkgname, version, type){
   if(['src', 'win', 'mac', 'linux', 'wasm'].indexOf(type) < 0){
     throw "Parameter 'type' must be one of src, win, mac, linux, wasm";
   } 
-  if(data.Package != package || data.Version != version) {
+  if(data.Package != pkgname || data.Version != version) {
     throw 'Package name or version does not match upload';
   }
   if(type == 'src' && data.Built) {
@@ -233,7 +228,7 @@ function parse_builder_fields(x){
 
 function merge_dependencies(x){
   var deps = [];
-  dependency_types.forEach(function(key){
+  rconstants.dependency_types.forEach(function(key){
     if(x[key]){
       deps = deps.concat(x[key].map(function(y){y.role = key; return y;}));
     }
@@ -342,18 +337,18 @@ function add_meta_fields(description, meta){
 
 router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, next){
   var user = req.params.user;
-  var package = req.params.package;
+  var pkgname = req.params.package;
   var version = req.params.version;
   var type = req.params.type;
   var md5 = req.params.md5;
-  var query = {_user : user, _type : type, Package : package};
+  var query = {_user : user, _type : type, Package : pkgname};
   var builder = parse_builder_fields(req.headers) || {};
-  var filename = get_filename(package, version, type, builder.distro);
+  var filename = get_filename(pkgname, version, type, builder.distro);
   crandb_store_file(req, md5, filename).then(function(filedata){
     if(type == 'src'){
-      var p1 = packages.countDocuments({_type: 'src', _indexed: true, '_rundeps': package});
-      var p2 = extract_json_metadata(bucket.openDownloadStream(md5), package);
-      var p3 = packages.find({_type: 'src', Package: package, _indexed: true}).project({_user:1}).next();
+      var p1 = packages.countDocuments({_type: 'src', _indexed: true, '_rundeps': pkgname});
+      var p2 = extract_json_metadata(bucket.openDownloadStream(md5), pkgname);
+      var p3 = packages.find({_type: 'src', Package: pkgname, _indexed: true}).project({_user:1}).next();
       return Promise.all([filedata, p1, p2, p3]);
     } else {
       return [filedata];
@@ -372,7 +367,7 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
       description['_published'] = new Date();
       add_meta_fields(description, builder);
       merge_dependencies(description);
-      validate_description(description, package, version, type);
+      validate_description(description, pkgname, version, type);
       description['_owner'] = get_repo_owner(description._upstream);
       description['_selfowned'] = is_self_owned(description);
       if(type == "src"){
@@ -380,10 +375,10 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
         add_meta_fields(description, headerdata); //contents.json
         description['_score'] = calculate_score(description);
         description['_indexed'] = is_indexed(description);
-        description['_nocasepkg'] = package.toLowerCase();
+        description['_nocasepkg'] = pkgname.toLowerCase();
         set_universes(description);
         if(description['_indexed'] === false && canonical){
-          description['_indexurl'] = `https://${canonical['_user']}.r-universe.dev/${package}`;
+          description['_indexurl'] = `https://${canonical['_user']}.r-universe.dev/${pkgname}`;
         }
       } else {
         query['Built.R'] = {$regex: '^' + parse_major_version(description.Built)};
@@ -404,7 +399,7 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
         return packages.insertOne(description);
       }).then(function(){
         if(type === 'src'){
-          return packages.deleteMany({_type : 'failure', _user : user, Package : package});
+          return packages.deleteMany({_type : 'failure', _user : user, Package : pkgname});
         }
       }).then(() => res.send(description));  
     }).catch(function(e){
@@ -415,9 +410,8 @@ router.put('/:user/packages/:package/:version/:type/:md5', function(req, res, ne
 
 router.post('/:user/packages/:package/:version/update', multerstore.none(), function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
   var version = req.params.version;
-  var query = {_type : 'src', _user : user, Package : package, Version: version};
+  var query = {_type : 'src', _user : user, Package : req.params.package, Version: version};
   var payload = req.body;
   Promise.resolve().then(function(){
     var fields = Object.keys(payload);
@@ -429,18 +423,18 @@ router.post('/:user/packages/:package/:version/update', multerstore.none(), func
 
 router.post('/:user/packages/:package/:version/failure', multerstore.none(), function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
+  var pkgname = req.params.package;
   var version = req.params.version;
   var builder = parse_builder_fields(req.body);
   var maintainer = `${builder.maintainer.name} <${builder.maintainer.email}>`;
-  var query = {_type : 'failure', _user : user, Package : package};
+  var query = {_type : 'failure', _user : user, Package : pkgname};
   var description = {...query, Version: version, Maintainer: maintainer, _published: new Date()};
   add_meta_fields(description, builder);
   description['_created'] = new Date();
   description['_owner'] = get_repo_owner(description._upstream);
   description['_selfowned'] = description._owner === user;
   description['_universes'] = [user]; //show failures in dashboard
-  description['_nocasepkg'] = package.toLowerCase();
+  description['_nocasepkg'] = pkgname.toLowerCase();
   packages.findOneAndReplace(query, description, {upsert: true})
     .then(() => res.send(description))
     .catch(error_cb(400, next))
@@ -451,10 +445,10 @@ router.post('/:user/packages/:package/:version/:type', multerstore.fields([{ nam
     return next(createError(400, "Missing parameter 'file' in upload"));
   }
   var user = req.params.user;
-  var package = req.params.package;
+  var pkgname = req.params.package;
   var version = req.params.version;
   var type = req.params.type;
-  var query = {_user : user, _type : type, Package : package};
+  var query = {_user : user, _type : type, Package : pkgname};
   var filepath = req.files.file[0].path;
   var filename = req.files.file[0].originalname;
   var md5 = md5file.sync(filepath);
@@ -462,8 +456,8 @@ router.post('/:user/packages/:package/:version/:type', multerstore.fields([{ nam
   var stream = fs.createReadStream(filepath);
   crandb_store_file(stream, md5, filename).then(function(filedata){
     if(type == 'src'){
-      var p1 = packages.countDocuments({_type: 'src', _indexed: true, '_rundeps': package});
-      var p2 = extract_json_metadata(bucket.openDownloadStream(md5), package);
+      var p1 = packages.countDocuments({_type: 'src', _indexed: true, '_rundeps': pkgname});
+      var p2 = extract_json_metadata(bucket.openDownloadStream(md5), pkgname);
       return Promise.all([filedata, p1, p2]);
     } else {
       return [filedata];
@@ -481,7 +475,7 @@ router.post('/:user/packages/:package/:version/:type', multerstore.fields([{ nam
       description['_published'] = new Date();
       add_meta_fields(description, builder);
       merge_dependencies(description);
-      validate_description(description, package, version, type);
+      validate_description(description, pkgname, version, type);
       description['_owner'] = get_repo_owner(description._upstream);
       description['_selfowned'] = is_self_owned(description);
       if(type == "src"){
@@ -489,7 +483,7 @@ router.post('/:user/packages/:package/:version/:type', multerstore.fields([{ nam
         add_meta_fields(description, headerdata); //contents.json
         description['_score'] = calculate_score(description);
         description['_indexed'] = is_indexed(description);
-        description['_nocasepkg'] = package.toLowerCase();
+        description['_nocasepkg'] = pkgname.toLowerCase();
         set_universes(description);
       } else {
         query['Built.R'] = {$regex: '^' + parse_major_version(description.Built)};
@@ -510,7 +504,7 @@ router.post('/:user/packages/:package/:version/:type', multerstore.fields([{ nam
         return packages.insertOne(description);
       }).then(function(){
         if(type === 'src'){
-          return packages.deleteMany({_type : 'failure', _user : user, Package : package});
+          return packages.deleteMany({_type : 'failure', _user : user, Package : pkgname});
         }
       }).then(() => res.send(description));
     }).catch(function(e){
@@ -524,13 +518,13 @@ router.post('/:user/packages/:package/:version/:type', multerstore.fields([{ nam
 /* HTTP PATCH does not require authentication, so this API is public */
 router.patch('/:user/packages/:package/:version/:type', function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
+  var pkgname = req.params.package;
   var version = req.params.version;
   var type = req.params.type || 'src'
-  var query = {_user : user, _type : type, Package : package, Version: version};
+  var query = {_user : user, _type : type, Package : pkgname, Version: version};
   packages.find(query).next().then(function(doc){
     if(!doc) {
-      throw `Failed to find package ${package} ${version} in ${user}`;
+      throw `Failed to find package ${pkgname} ${version} in ${user}`;
     }
     const now = new Date();
     /* Try to prevent hammering of the GH API. However note that the _rebuild_pending field
@@ -539,13 +533,13 @@ router.patch('/:user/packages/:package/:version/:type', function(req, res, next)
     if(rebuild){
       const minutes = (now - rebuild) / 60000;
       if(minutes < 60){
-        res.status(429).send(`A rebuild of ${package} ${version} was already triggered ${Math.round(minutes)} minutes ago.`);
+        res.status(429).send(`A rebuild of ${pkgname} ${version} was already triggered ${Math.round(minutes)} minutes ago.`);
         return;
       }
     }
     var buildurl = doc._buildurl;
     if(!buildurl) {
-      throw `Failed to find _buildurl in ${package} ${version}`;
+      throw `Failed to find _buildurl in ${pkgname} ${version}`;
     }
     const pattern = new RegExp('https://github.com/(r-universe/.*/actions/runs/[0-9]+)');
     const match = buildurl.match(pattern);
@@ -553,12 +547,12 @@ router.patch('/:user/packages/:package/:version/:type', function(req, res, next)
       throw 'Did not recognize github action url'
     }
     const run_path = match[1];
-    return tools.get_submodule_hash(user, package).then(function(sha){
+    return get_submodule_hash(user, pkgname).then(function(sha){
       if(sha !== doc._commit.id){
-        throw `Build version of ${package} not match ${user} monorepo. Package may have been updated or removed in the mean time.` +
+        throw `Build version of ${pkgname} not match ${user} monorepo. Package may have been updated or removed in the mean time.` +
           `\nUpstream: ${sha}\nThis build: ${doc._commit.id}`
       }
-      return tools.trigger_rebuild(run_path).then(function(){
+      return trigger_rebuild(run_path).then(function(){
         return packages.updateOne(
           { _id: doc['_id'] },
           { "$set": {"_rebuild_pending": now }}
@@ -585,7 +579,7 @@ router.patch("/:user/api/recheck/:target",function(req, res, next) {
       var minutes = (doc['_recheck_date'] - now) / 60000;
       return res.status(429).send(`A recheck of ${doc.Package} was already triggered ${Math.round(minutes)} minutes ago.`);
     }
-    return tools.trigger_recheck(doc._user, doc.Package).then(function(){
+    return trigger_recheck(doc._user, doc.Package).then(function(){
       return packages.updateOne(
         { _id: doc['_id'] },
         { "$set": {"_recheck_date": now }}
@@ -599,8 +593,7 @@ router.patch("/:user/api/recheck/:target",function(req, res, next) {
 /* This API is called by the CI to update the status */
 router.post("/:user/api/recheck/:package",function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
-  var query = {_user : user, _type : 'src', Package: package};
+  var query = {_user : user, _type : 'src', Package: req.params.package};
   return packages.find(query).next().then(function(doc){
     return packages.updateOne(
       { _id: doc['_id'] },
@@ -635,10 +628,10 @@ router.post('/:user/api/reindex', function(req, res, next) {
   });
 });
 
-function extract_json_metadata(input, package){
-  return tools.extract_multi_files(input, [`${package}/extra/contents.json`]).then(function([contents]){
+function extract_json_metadata(input, pkgname){
+  return extract_multi_files(input, [`${pkgname}/extra/contents.json`]).then(function([contents]){
     if(!contents){
-      throw `Source package did not contain ${package}/extra/contents.json`;
+      throw `Source package did not contain ${pkgname}/extra/contents.json`;
     }
     var metadata = JSON.parse(contents);
     if(!metadata.assets){
@@ -651,4 +644,4 @@ function extract_json_metadata(input, package){
   });
 }
 
-module.exports = router;
+export default router;

--- a/routes/packages.js
+++ b/routes/packages.js
@@ -10,6 +10,7 @@ import tar from 'tar-stream';
 import crypto from 'node:crypto';
 import rconstants from 'r-constants';
 import {match_macos_arch, trigger_rebuild, trigger_recheck, get_submodule_hash, extract_multi_files} from '../src/tools.js';
+import {packages, bucket, chunks, db} from '../src/db.js';
 
 /* Local variables */
 const multerstore = multer({ dest: '/tmp/' });

--- a/routes/repos.js
+++ b/routes/repos.js
@@ -4,6 +4,7 @@ import createError from 'http-errors';
 import zlib from 'node:zlib';
 import gunzip from 'gunzip-maybe';
 import {qf, pkgfields, doc_to_dcf, group_package_data, match_macos_arch} from '../src/tools.js';
+import {packages, bucket} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/repos.js
+++ b/routes/repos.js
@@ -1,15 +1,11 @@
 /* Packages */
-const express = require('express');
-const createError = require('http-errors');
-const zlib = require('zlib');
-const gunzip = require('gunzip-maybe');
+import express from 'express';
+import createError from 'http-errors';
+import zlib from 'node:zlib';
+import gunzip from 'gunzip-maybe';
+import {qf, pkgfields, doc_to_dcf, group_package_data, match_macos_arch} from '../src/tools.js';
+
 const router = express.Router();
-const tools = require("../src/tools.js");
-const pkgfields = tools.pkgfields;
-const doc_to_dcf = tools.doc_to_dcf;
-const group_package_data = tools.group_package_data;
-const match_macos_arch = tools.match_macos_arch;
-const qf = tools.qf;
 
 function error_cb(status, next) {
   return function(err) {
@@ -342,7 +338,7 @@ router.get('/:user/api/ls', function(req, res, next) {
 
 router.get('/:user/api/packages/:package?', function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
+  var pkgname = req.params.package;
   var projection = {_id:0};
   if(req.query.fields){
     var projection = {Package:1, _type:1, _user:1, _indexed: 1, _id:0};
@@ -359,10 +355,10 @@ router.get('/:user/api/packages/:package?', function(req, res, next) {
       }
     });
   }
-  if(package){
-    packages.find({_user : user, Package : package}).project(projection).toArray().then(function(docs){
+  if(pkgname){
+    packages.find({_user : user, Package : pkgname}).project(projection).toArray().then(function(docs){
       if(!docs.length){
-        return res.status(404).send(`No package '${package}' found in https://${user}.r-universe.dev`);
+        return res.status(404).send(`No package '${pkgname}' found in https://${user}.r-universe.dev`);
       }
       res.send(group_package_data(docs));
     }).catch(error_cb(400, next));
@@ -1123,8 +1119,8 @@ router.get("/:user/stats/ranksearch", function(req, res, next) {
 
 /* Simple 1 package revdep cases; see above for aggregates */
 router.get('/:user/stats/usedby', function(req, res, next) {
-  var package = req.query.package;
-  var query = qf({_user: req.params.user, _type: 'src', '_dependencies.package': package, '_indexed': true}, req.query.all);
+  var pkgname = req.query.package;
+  var query = qf({_user: req.params.user, _type: 'src', '_dependencies.package': pkgname, '_indexed': true}, req.query.all);
   var cursor = packages.find(query).project({_id: 0, owner: '$_owner', package: "$Package"}).sort({'_stars': -1});
   cursor.hasNext().then(function(){
     cursor.stream({transform: doc_to_ndjson}).pipe(res.type('text/plain'));
@@ -1133,8 +1129,8 @@ router.get('/:user/stats/usedby', function(req, res, next) {
 
 router.get('/:user/stats/usedbyorg', function(req, res, next) {
   var user = req.params.user;
-  var package = req.query.package;
-  var query = qf({_user: user, _type: 'src', '_dependencies.package': package, '_indexed': true}, req.query.all);
+  var pkgname = req.query.package;
+  var query = qf({_user: user, _type: 'src', '_dependencies.package': pkgname, '_indexed': true}, req.query.all);
   var cursor = packages.aggregate([
     {$match:query},
     {$group : {
@@ -1245,4 +1241,4 @@ router.get('/:user/readme/:pkg.html', function(req, res, next){
   res.redirect(301, `/${req.params.user}/${req.params.pkg}/doc/readme.html`);
 });
 
-module.exports = router;
+export default router;

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,6 +1,7 @@
 /* Packages */
-const express = require('express');
-const createError = require('http-errors');
+import express from 'express';
+import createError from 'http-errors';
+
 const router = express.Router();
 
 function error_cb(status, next) {
@@ -124,4 +125,4 @@ router.get("/:user/stats/powersearch", function(req, res, next) {
   res.redirect(req.url.replace("stats/powersearch", "api/search"))
 });
 
-module.exports = router;
+export default router;

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,6 +1,7 @@
 /* Packages */
 import express from 'express';
 import createError from 'http-errors';
+import {packages} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/shared.js
+++ b/routes/shared.js
@@ -1,9 +1,10 @@
-var express = require('express');
-var createError = require('http-errors');
-var router = express.Router();
-var tools = require("../src/tools.js");
-var webr = require("@r-universe/webr");
-var session = new webr.WebR();
+import express from 'express';
+import createError from 'http-errors';
+import {get_cran_desc} from '../src/tools.js';
+import webr from '@r-universe/webr';
+
+const router = express.Router();
+const session = new webr.WebR();
 session.init();
 
 function error_cb(status, next) {
@@ -14,14 +15,14 @@ function error_cb(status, next) {
 }
 
 router.get('/shared/redirect/:package*', function(req, res, next) {
-  var package = req.params.package;
-  find_cran_package(package).then(function(x){
+  var pkgname = req.params.package;
+  find_cran_package(pkgname).then(function(x){
     if(!x){
-      find_cran_package(package, 'failure').then(function(y){
+      find_cran_package(pkgname, 'failure').then(function(y){
         if(y){
-          res.status(404).type('text/plain').send(`CRAN package ${package} failed to build on r-universe: ${y._buildurl}`);
+          res.status(404).type('text/plain').send(`CRAN package ${pkgname} failed to build on r-universe: ${y._buildurl}`);
         } else {
-          res.status(404).type('text/plain').send(`Package ${package} not found on CRAN.`);
+          res.status(404).type('text/plain').send(`Package ${pkgname} not found on CRAN.`);
         }
       });
     } else {
@@ -66,7 +67,7 @@ router.get('/shared/redirect/:package*', function(req, res, next) {
 });
 
 router.get('/shared/cranstatus/:package', function(req, res, next) {
-  tools.get_cran_desc(req.params.package).then(function(info){
+  get_cran_desc(req.params.package).then(function(info){
     res.set('Cache-Control', 'max-age=3600, public').send(info);
   }).catch(error_cb(400, next));
 });
@@ -92,8 +93,8 @@ router.get('/shared/mongostatus', function(req, res, next) {
   }).catch(error_cb(400, next))
 });
 
-function find_cran_package(package, type = 'src'){
-  var pkgname = package.toLowerCase();
+function find_cran_package(pkgname, type = 'src'){
+  var pkgname = pkgname.toLowerCase();
   return packages.findOne({_nocasepkg : pkgname, _type : type, _user : 'cran'}).then(function(x){
     if(x) return x;
     /* fallback for packages misssing from the CRAN mirror for whatever reason */
@@ -105,4 +106,4 @@ function find_cran_package(package, type = 'src'){
   });
 }
 
-module.exports = router;
+export default router;

--- a/routes/shared.js
+++ b/routes/shared.js
@@ -1,7 +1,8 @@
 import express from 'express';
 import createError from 'http-errors';
-import {get_cran_desc} from '../src/tools.js';
 import webr from '@r-universe/webr';
+import {get_cran_desc} from '../src/tools.js';
+import {packages} from '../src/db.js';
 
 const router = express.Router();
 const session = new webr.WebR();

--- a/routes/snapshot.js
+++ b/routes/snapshot.js
@@ -4,6 +4,7 @@ import zlib from 'node:zlib';
 import archiver from 'archiver';
 import path from 'node:path';
 import {pkgfields, doc_to_dcf, get_extracted_file} from '../src/tools.js';
+import {packages, bucket} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/snapshot.js
+++ b/routes/snapshot.js
@@ -1,12 +1,11 @@
-const express = require('express');
-const createError = require('http-errors');
-const zlib = require('zlib');
+import express from 'express';
+import createError from 'http-errors';
+import zlib from 'node:zlib';
+import archiver from 'archiver';
+import path from 'node:path';
+import {pkgfields, doc_to_dcf, get_extracted_file} from '../src/tools.js';
+
 const router = express.Router();
-const archiver = require('archiver');
-const path = require('node:path');
-const tools = require("../src/tools.js");
-const pkgfields = tools.pkgfields;
-const doc_to_dcf = tools.doc_to_dcf;
 
 function error_cb(status, next) {
   return function(err){
@@ -60,7 +59,6 @@ function packages_snapshot(files, archive, types){
   var indexes = {};
   var promises = [];
   files.forEach(function(x){
-    var package = x.Package;
     var date = x._created;
     if(types.includes(x._type)){
       var hash = x.MD5sum;
@@ -81,10 +79,10 @@ function packages_snapshot(files, archive, types){
   /* Extract html manual pages. This is a bit slower so doing this last */
   if(types.includes('docs')){
     files.filter(x => x._type == 'src').forEach(function(x){
-      var package = x.Package;
+      var pkgname = x.Package;
       var date = x._created;
-      promises.push(tools.get_extracted_file({_id: x._id}, `${package}/extra/${package}.html`).then(function(buf){
-        return archive.append(buf, { name: `docs/${package}.html`, date: date });
+      promises.push(get_extracted_file({_id: x._id}, `${pkgname}/extra/${pkgname}.html`).then(function(buf){
+        return archive.append(buf, { name: `docs/${pkgname}.html`, date: date });
       }).catch(err => console.log(err)));
     });
   }
@@ -132,4 +130,4 @@ router.get('/:user/api/snapshot/:format?', function(req, res, next) {
   }).catch(error_cb(400, next));
 });
 
-module.exports = router;
+export default router;

--- a/routes/v2.js
+++ b/routes/v2.js
@@ -1,8 +1,8 @@
 import express from 'express';
 import createError from 'http-errors';
 import xmlbuilder from 'xmlbuilder';
-import {load as cheerio_load} from 'cheerio';
 import hljs from 'highlight.js';
+import {load as cheerio_load} from 'cheerio';
 import {send_extracted_file, tar_index_files, test_if_universe_exists, get_extracted_file} from '../src/tools.js';
 
 const router = express.Router();

--- a/routes/v2.js
+++ b/routes/v2.js
@@ -4,6 +4,7 @@ import xmlbuilder from 'xmlbuilder';
 import hljs from 'highlight.js';
 import {load as cheerio_load} from 'cheerio';
 import {send_extracted_file, tar_index_files, test_if_universe_exists, get_extracted_file} from '../src/tools.js';
+import {packages, bucket} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/v2.js
+++ b/routes/v2.js
@@ -1,12 +1,11 @@
-const express = require('express');
-const createError = require('http-errors');
-const xmlbuilder = require('xmlbuilder');
-const cheerio = require('cheerio');
-const hljs = require('highlight.js');
+import express from 'express';
+import createError from 'http-errors';
+import xmlbuilder from 'xmlbuilder';
+import {load as cheerio_load} from 'cheerio';
+import hljs from 'highlight.js';
+import {send_extracted_file, tar_index_files, test_if_universe_exists, get_extracted_file} from '../src/tools.js';
+
 const router = express.Router();
-const tools = require("../src/tools.js");
-const send_extracted_file = tools.send_extracted_file;
-const tar_index_files = tools.tar_index_files;
 
 /* Error generator */
 function error_cb(status, next) {
@@ -18,7 +17,7 @@ function error_cb(status, next) {
 
 router.get('/:user', function(req, res, next) {
   const user = req.params.user;
-  tools.test_if_universe_exists(user).then(function(exists){
+  test_if_universe_exists(user).then(function(exists){
     if(exists){
       res.set('Cache-control', 'private'); //html or json
       const accept = req.headers['accept'];
@@ -42,23 +41,23 @@ router.get('/:user/robots.txt', function(req, res, next) {
 // validate that universe or package exists, possibly fix case mismatch, otherwise 404
 router.get("/:user/:package*", function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
-  real_package_home(user, package).then(function(x){
+  var pkgname = req.params.package;
+  real_package_home(user, pkgname).then(function(x){
     var realowner = x._realowner || x._user;
     if(x._user != user){
       /* nginx does not understand cross-domain redirect with relative path */
-      res.redirect(req.path.replace(`/${user}/${package}`, `https://${x._user}.r-universe.dev/${x.Package}`));
-    } else if(x.Package != package){
-      res.redirect(req.path.replace(`/${user}/${package}`, `/${user}/${x.Package}`));
+      res.redirect(req.path.replace(`/${user}/${pkgname}`, `https://${x._user}.r-universe.dev/${x.Package}`));
+    } else if(x.Package != pkgname){
+      res.redirect(req.path.replace(`/${user}/${pkgname}`, `/${user}/${x.Package}`));
     } else if(req.params['0'] === "" && user === 'cran' && realowner !== 'cran' ) {
       /* req.params['0'] means only redirect the html dasbhoard, not pkg content */
-      res.redirect(req.path.replace(`/${user}/${package}`, `https://${realowner}.r-universe.dev/${x.Package}`));
+      res.redirect(req.path.replace(`/${user}/${pkgname}`, `https://${realowner}.r-universe.dev/${x.Package}`));
     } else {
       next();
     }
   }).catch(function(){
-    return find_package(user, package, 'failure').then(function(y){
-      res.status(404).type('text/plain').send(`Package ${user}/${package} exists but failed to build: ${y._buildurl}`);
+    return find_package(user, pkgname, 'failure').then(function(y){
+      res.status(404).type('text/plain').send(`Package ${user}/${pkgname} exists but failed to build: ${y._buildurl}`);
     });
   }).catch(error_cb(404, next));
 
@@ -75,15 +74,15 @@ router.get("/:user/:package/json", function(req, res, next) {
 
 router.get("/:user/:package/files", function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
-  var query = {_user : user, Package : package};
+  var pkgname = req.params.package;
+  var query = {_user : user, Package : pkgname};
   packages.find(query).sort({"Built.R" : -1}).toArray().then(docs => res.send(docs)).catch(error_cb(400, next));
 });
 
 router.get("/:user/:package/buildlog", function(req, res, next) {
   var user = req.params.user;
-  var package = req.params.package;
-  var query = {_user : user, Package : package};
+  var pkgname = req.params.package;
+  var query = {_user : user, Package : pkgname};
   packages.find(query).sort({"_created" : -1}).limit(1).next().then(function(x){
     console.log(x)
     res.redirect(x['_buildurl'])
@@ -92,67 +91,67 @@ router.get("/:user/:package/buildlog", function(req, res, next) {
 
 /* Match CRAN / R dynamic help */
 router.get("/:user/:package/DESCRIPTION", function(req, res, next) {
-  var package = req.params.package;
-  var query = {_user: req.params.user, _type: 'src', Package: package};
-  var filename = `${package}/DESCRIPTION`;
+  var pkgname = req.params.package;
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
+  var filename = `${pkgname}/DESCRIPTION`;
   send_extracted_file(query, filename, req, res).catch(error_cb(400, next));
 });
 
 /* Match CRAN / R dynamic help */
 router.get('/:user/:package/NEWS:ext?', function(req, res, next){
-  var package = req.params.package;
-  var query = {_user: req.params.user, _type: 'src', Package: package};
+  var pkgname = req.params.package;
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
   var ext = req.params.ext || '.html';
-  var filename = `${package}/extra/NEWS${ext}`
+  var filename = `${pkgname}/extra/NEWS${ext}`
   send_extracted_file(query, filename, req, res).catch(error_cb(400, next));
 });
 
 /* Match CRAN */
 router.get('/:user/:package/:file.pdf', function(req, res, next){
-  var package = req.params.package;
-  if(package != req.params.file){
-    return res.status(404).send(`Did you mean ${package}.pdf`)
+  var pkgname = req.params.package;
+  if(pkgname != req.params.file){
+    return res.status(404).send(`Did you mean ${pkgname}.pdf`)
   }
-  var query = {_user: req.params.user, _type: 'src', Package: package};
-  send_extracted_file(query, `${package}/manual.pdf`, req, res).catch(error_cb(400, next));
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
+  send_extracted_file(query, `${pkgname}/manual.pdf`, req, res).catch(error_cb(400, next));
 });
 
 /* Match CRAN */
 router.get('/:user/:package/citation:ext?', function(req, res, next){
-  var package = req.params.package;
-  var query = {_user: req.params.user, _type: 'src', Package: package};
+  var pkgname = req.params.package;
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
   var ext = req.params.ext || '.html';
-  var filename = `${package}/extra/citation${ext}`
+  var filename = `${pkgname}/extra/citation${ext}`
   send_extracted_file(query, filename, req, res).catch(error_cb(400, next));
 });
 
-function doc_path(file, package){
+function doc_path(file, pkgname){
   switch(file.toLowerCase()) {
     case "readme.html":
-      return `${package}/extra/readme.html`;
+      return `${pkgname}/extra/readme.html`;
     case "readme.md":
-      return `${package}/extra/readme.md`;
+      return `${pkgname}/extra/readme.md`;
     case `manual.html`:
-      return `${package}/extra/${package}.html`;
+      return `${pkgname}/extra/${pkgname}.html`;
     default:
-      return `${package}/inst/doc/${file}`;
+      return `${pkgname}/inst/doc/${file}`;
   }
 }
 
 /* processed html-snipped (not a full doc) */
 router.get('/:user/:package/doc/readme', function(req, res, next){
   var user = req.params.user;
-  var package = req.params.package;
-  var query = {_user: user, _type: 'src', Package: package};
-  tools.get_extracted_file(query, `${package}/extra/readme.html`).then(function(html){
+  var pkgname = req.params.package;
+  var query = {_user: user, _type: 'src', Package: pkgname};
+  get_extracted_file(query, `${pkgname}/extra/readme.html`).then(function(html){
     if(req.query.highlight === 'hljs'){
-      const $ = cheerio.load(html, null, false);
+      const $ = cheerio_load(html, null, false);
       $('code[class^="language-"]').each(function(i, el){
         try { //hljs errors for unsupported languages
           var el = $(el)
           var lang = el.attr('class').substring(9);
-          var matcher = new RegExp(`([a-z]+::)?(install_github|pak|pkg_install)\\(.${user}/${package}.\\)`, "i");
-          var input = el.text().replace(matcher, `# $&\ninstall.packages("${package}", repos = c('https://${user}.r-universe.dev', 'https://cloud.r-project.org'))`)
+          var matcher = new RegExp(`([a-z]+::)?(install_github|pak|pkg_install)\\(.${user}/${pkgname}.\\)`, "i");
+          var input = el.text().replace(matcher, `# $&\ninstall.packages("${pkgname}", repos = c('https://${user}.r-universe.dev', 'https://cloud.r-project.org'))`)
           var out = hljs.highlight(input, {language: lang}).value
           el.addClass("hljs").empty().append(out);
         } catch (e) { }
@@ -167,16 +166,16 @@ router.get('/:user/:package/doc/readme', function(req, res, next){
 router.get('/:user/:package/doc/page/:id', function(req, res, next){
   var user = req.params.user;
   var page = req.params.id;
-  var package = req.params.package;
-  var query = {_user: req.params.user, _type: 'src', Package: package};
-  tools.get_extracted_file(query, `${package}/extra/${package}.html`).then(function(html){
-    const $ = cheerio.load(html, null, false);
+  var pkgname = req.params.package;
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
+  get_extracted_file(query, `${pkgname}/extra/${pkgname}.html`).then(function(html){
+    const $ = cheerio_load(html, null, false);
     const el = $(`#${page.replace(".", "\\.")}`);
     el.find(".help-page-title").replaceWith(el.find(".help-page-title h2"));
     el.find('a').each(function(i, elm) {
       var link = $(this).attr("href");
       if(link && link.charAt(0) == '#'){
-        $(this).attr("href", `https://${user}.r-universe.dev/${package}/doc/manual.html` + link);
+        $(this).attr("href", `https://${user}.r-universe.dev/${pkgname}/doc/manual.html` + link);
       }
     });
     el.find('hr').remove();
@@ -185,8 +184,8 @@ router.get('/:user/:package/doc/page/:id', function(req, res, next){
 });
 
 router.get('/:user/:package/doc', function(req, res, next){
-  var package = req.params.package;
-  var query = {_user: req.params.user, _type: 'src', Package: package};
+  var pkgname = req.params.package;
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
   return packages.find(query, {limit:1}).sort({"_created" : -1}).next().then(function(x){
     if(!x)
       throw `Package ${query.Package} not found in ${query['_user']}`;
@@ -194,7 +193,7 @@ router.get('/:user/:package/doc', function(req, res, next){
   }).then(function(index){
     var output = [];
     index.files.forEach(function(x){
-      var m = x.filename.match(`^${package}/inst/doc/(.+)$`);
+      var m = x.filename.match(`^${pkgname}/inst/doc/(.+)$`);
       if(m) output.push(m[1]);
     });
     res.send(output);
@@ -202,9 +201,9 @@ router.get('/:user/:package/doc', function(req, res, next){
 });
 
 router.get('/:user/:package/doc/:file', function(req, res, next){
-  var package = req.params.package;
-  var query = {_user: req.params.user, _type: 'src', Package: package};
-  send_extracted_file(query, doc_path(req.params.file, package), req, res).catch(error_cb(400, next));
+  var pkgname = req.params.package;
+  var query = {_user: req.params.user, _type: 'src', Package: pkgname};
+  send_extracted_file(query, doc_path(req.params.file, pkgname), req, res).catch(error_cb(400, next));
 });
 
 router.get('/:user/:package/sitemap.xml', function(req, res, next) {
@@ -242,19 +241,19 @@ router.get('/:user/:package/sitemap.xml', function(req, res, next) {
 
 //This redirects cran.r-universe.dev/pkg to the canonical home, if any
 //Todo: allow to by pass to access resources (e.g. vignettes) from the cran copy
-function real_package_home(user, package){
+function real_package_home(user, pkgname){
   //if(user === 'cran'){
   //  return packages.findOne({'Package': package, '_type': 'src', '_indexed': true}).then(function(x){
   //    if(x) return x;
   //    return find_package(user, package);
   //  });
   //} else {
-    return find_package(user, package);
+    return find_package(user, pkgname);
   //}
 }
 
-function find_package(user, package, type = 'src'){
-  var nocasepkg = package.toLowerCase();
+function find_package(user, pkgname, type = 'src'){
+  var nocasepkg = pkgname.toLowerCase();
   var query = {'_user': user, '_nocasepkg': nocasepkg, '_type': type};
   return packages.findOne(query).then(function(x){
     if(x) return x;
@@ -266,9 +265,9 @@ function find_package(user, package, type = 'src'){
     };
     return packages.findOne(query).then(function(x){
       if(x) return x;
-      throw `Package ${user}/${package} not found`;
+      throw `Package ${user}/${pkgname} not found`;
     });
   });
 }
 
-module.exports = router;
+export default router;

--- a/routes/webr.js
+++ b/routes/webr.js
@@ -2,6 +2,7 @@ import express from 'express';
 import createError from 'http-errors';
 import webr from '@r-universe/webr';
 import {get_extracted_file_multi} from '../src/tools.js';
+import {packages} from '../src/db.js';
 
 const router = express.Router();
 

--- a/routes/webr.js
+++ b/routes/webr.js
@@ -3,6 +3,7 @@ import createError from 'http-errors';
 import webr from '@r-universe/webr';
 import {get_extracted_file_multi} from '../src/tools.js';
 import {packages} from '../src/db.js';
+import {Buffer} from "node:buffer";
 
 const router = express.Router();
 

--- a/src/db.js
+++ b/src/db.js
@@ -1,6 +1,6 @@
 /* Database */
-const assert = require('assert');
-const mongodb = require('mongodb');
+import {MongoClient, GridFSBucket} from 'mongodb';
+
 const HOST = process.env.CRANLIKE_MONGODB_SERVER || '127.0.0.1';
 const PORT = process.env.CRANLIKE_MONGODB_PORT || 27017;
 const USER = process.env.CRANLIKE_MONGODB_USERNAME || 'root';
@@ -10,13 +10,13 @@ const URL = 'mongodb://' + AUTH + HOST + ':' + PORT;
 
 /* Connect to database */
 console.log("Connecting to database....")
-const connection = mongodb.MongoClient.connect(URL, { useUnifiedTopology: true });
+const connection = MongoClient.connect(URL, { useUnifiedTopology: true });
 connection.then(async function(client) {
   console.log("Connected to MongoDB!")
   global.db = client.db('cranlike');
   //console.log(client)
   //console.log(db)
-  global.bucket = new mongodb.GridFSBucket(db, {bucketName: 'files'});
+  global.bucket = new GridFSBucket(db, {bucketName: 'files'});
   global.packages = db.collection('packages');
   global.chunks = db.collection('files.chunks');
 
@@ -97,4 +97,4 @@ async function rebuild_indexes(){
   console.log(indexes.map(x => x.name));
 }
 
-module.exports = connection;
+export default connection;

--- a/src/db.js
+++ b/src/db.js
@@ -1,5 +1,6 @@
 /* Database */
 import {MongoClient, GridFSBucket} from 'mongodb';
+import process from "node:process";
 
 const HOST = process.env.CRANLIKE_MONGODB_SERVER || '127.0.0.1';
 const PORT = process.env.CRANLIKE_MONGODB_PORT || 27017;

--- a/src/db.js
+++ b/src/db.js
@@ -10,25 +10,18 @@ const URL = 'mongodb://' + AUTH + HOST + ':' + PORT;
 
 /* Connect to database */
 console.log("Connecting to database....")
-const connection = MongoClient.connect(URL, { useUnifiedTopology: true });
-connection.then(async function(client) {
-  console.log("Connected to MongoDB!")
-  global.db = client.db('cranlike');
-  //console.log(client)
-  //console.log(db)
-  global.bucket = new GridFSBucket(db, {bucketName: 'files'});
-  global.packages = db.collection('packages');
-  global.chunks = db.collection('files.chunks');
+export const client = await MongoClient.connect(URL, { useUnifiedTopology: true });
+export const db = client.db('cranlike');
+export const bucket = new GridFSBucket(db, {bucketName: 'files'});
+export const packages = db.collection('packages');
+export const chunks = db.collection('files.chunks');
+console.log("Connected to MongoDB!");
 
-  //removes and recreates all indexes
-  if(process.env.REBUILD_INDEXES){
-    console.log("REBUILDING INDEXES!")
-    rebuild_indexes();
-  }
-}).catch(function(error){
-  console.log("Failed to connect to mongodb!\n" + error)
-  throw error;
-});
+//removes and recreates all indexes
+if(process.env.REBUILD_INDEXES){
+  console.log("REBUILDING INDEXES!")
+  rebuild_indexes();
+}
 
 async function rebuild_indexes(){
   //print (or drop) indexes
@@ -96,5 +89,3 @@ async function rebuild_indexes(){
   var indexes = await packages.indexes();
   console.log(indexes.map(x => x.name));
 }
-
-export default connection;

--- a/src/tools.js
+++ b/src/tools.js
@@ -4,6 +4,7 @@ import gunzip from 'gunzip-maybe';
 import mime from 'mime';
 import {packages, bucket} from '../src/db.js';
 import {Buffer} from "node:buffer";
+import process from "node:process";
 
 /* Fields included in PACKAGES indices */
 export const pkgfields = {_id: 1, _type:1, _dependencies: 1, Filesize: '$_filesize', Distro: '$_distro',

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,16 +1,15 @@
 /* dummy token for GH api limits */
-const tar = require('tar-stream');
-const gunzip = require('gunzip-maybe');
-const mime = require('mime');
-const path = require('path');
+import tar from 'tar-stream';
+import gunzip from 'gunzip-maybe';
+import mime from 'mime';
 
 /* Fields included in PACKAGES indices */
-const pkgfields = {_id: 1, _type:1, _dependencies: 1, Filesize: '$_filesize', Distro: '$_distro',
+export const pkgfields = {_id: 1, _type:1, _dependencies: 1, Filesize: '$_filesize', Distro: '$_distro',
   Package: 1, Version: 1, Depends: 1, Suggests: 1, License: 1,
   NeedsCompilation: 1, Imports: 1, LinkingTo: 1, Enhances: 1, License_restricts_use: 1,
   OS_type: 1, Priority: 1, License_is_FOSS: 1, Archs: 1, Path: 1, MD5sum: 1, Built: 1};
 
-function qf(x, query_by_user_or_maintainer){
+export function qf(x, query_by_user_or_maintainer){
   const user = x._user;
   if(user == ":any"){
     delete x._user;
@@ -39,7 +38,7 @@ function fetch_github(url, opt = {}){
 }
 
 /* true if we either have packages in the db, or an upstream monorepo exists */
-function test_if_universe_exists(user){
+export function test_if_universe_exists(user){
   if(user === ':any') return Promise.resolve(true);
   const url = 'https://github.com/r-universe/' + user;
   return packages.findOne({'_universes': user}).then(function(x){
@@ -58,12 +57,12 @@ function find_by_query(query){
   });
 }
 
-function get_registry_info(user){
+export function get_registry_info(user){
   const url = 'https://api.github.com/repos/r-universe/' + user + '/actions/workflows/sync.yml/runs?per_page=1&status=completed';
   return fetch_github(url);
 }
 
-function get_submodule_hash(user, submodule){
+export function get_submodule_hash(user, submodule){
   const url = `https://api.github.com/repos/r-universe/${user}/git/trees/HEAD`
   return fetch_github(url).then(function(data){
     var info = data.tree.find(file => file.path == submodule);
@@ -73,7 +72,7 @@ function get_submodule_hash(user, submodule){
   });
 }
 
-function trigger_rebuild(run_path){
+export function trigger_rebuild(run_path){
   const rebuild_token = process.env.REBUILD_TOKEN;
   if(!rebuild_token)
     throw "No rebuild_token available";
@@ -84,12 +83,12 @@ function trigger_rebuild(run_path){
   });
 }
 
-function trigger_recheck(user, package, which = 'strong'){
+export function trigger_recheck(user, pkg, which = 'strong'){
   const rebuild_token = process.env.REBUILD_TOKEN;
   if(!rebuild_token)
     throw "No rebuild_token available";
   const url = `https://api.github.com/repos/r-universe/${user}/actions/workflows/recheck.yml/dispatches`;
-  const params = {ref: 'master', inputs: {package: package, which: which}};
+  const params = {ref: 'master', inputs: {package: pkg, which: which}};
   return fetch_github(url, {
     method: 'POST',
     body: JSON.stringify(params),
@@ -99,7 +98,7 @@ function trigger_recheck(user, package, which = 'strong'){
 
 function parse_description(desc){
   var fields = desc.replace(/\n[\t ]+/g, ' ').split("\n")
-  var package = fields.find(x => x.match(/^Package:/i));
+  var pkg = fields.find(x => x.match(/^Package:/i));
   var version = fields.find(x => x.match(/^Version:/i));
   var date = fields.find(x => x.match(/^Date\/Publication:/i));
   var urls = fields.find(x => x.match(/^URL:/i));
@@ -109,7 +108,7 @@ function parse_description(desc){
     .map(x => x.replace('http://', 'https://'))
     .map(x => x.replace(/#.*/, ''));
   return {
-    package: package ? package.substring(9) : "parse failure",
+    package: pkg ? pkg.substring(9) : "parse failure",
     version: version ? version.substring(9) : "parse failure",
     date: date ? date.substring(18) : "parse failure",
     urls: [...new Set(urlarray.map(x => x.replace(/\/issues$/, "")))]
@@ -130,17 +129,17 @@ function get_cran_url(path){
   });
 }
 
-function get_cran_desc(package){
-  return get_cran_url(`/web/packages/${package}/DESCRIPTION`).then(function(response){
+export function get_cran_desc(pkg){
+  return get_cran_url(`/web/packages/${pkg}/DESCRIPTION`).then(function(response){
     if (response.ok) {
       return response.text().then(parse_description);
     } else if(response.status == 404) {
-      return get_cran_url(`/src/contrib/Archive/${package}/`).then(function(res2){
+      return get_cran_url(`/src/contrib/Archive/${pkg}/`).then(function(res2){
         if(res2.ok){
-          return {package:package, version: "archived"};
+          return {package:pkg, version: "archived"};
         }
         if(res2.status == 404){
-          return {package:package, version: null};
+          return {package:pkg, version: null};
         }
       });
     }
@@ -175,7 +174,7 @@ function pipe_everything_to(stream, output) {
   });
 }
 
-function send_extracted_file(query, filename, req, res){
+export function send_extracted_file(query, filename, req, res){
   return find_by_query(query).then(function(hash){
     var etag = etagify(hash);
     if(etag === req.header('If-None-Match')){
@@ -223,7 +222,7 @@ function send_file_from_tar(input, res, filename){
   });
 }
 
-function extract_multi_files(input, files){
+export function extract_multi_files(input, files){
   var output = Array(files.length);
   return new Promise(function(resolve, reject) {
     function process_entry(header, filestream, next_entry) {
@@ -249,7 +248,7 @@ function extract_multi_files(input, files){
   });
 }
 
-function get_extracted_file_multi(query, files){
+export function get_extracted_file_multi(query, files){
   return find_by_query(query).then(function(hash){
     return extract_multi_files(bucket.openDownloadStream(hash), files).then(function(buffers){
       files.forEach(function(x, i){
@@ -262,11 +261,11 @@ function get_extracted_file_multi(query, files){
   });
 }
 
-function get_extracted_file(query, filename){
+export function get_extracted_file(query, filename){
   return get_extracted_file_multi(query, [filename]).then(x => x[0]);
 }
 
-function tar_index_files(input){
+export function tar_index_files(input){
   let files = [];
   let extract = tar.extract({allowUnknownFormat: true});
   return new Promise(function(resolve, reject) {
@@ -350,7 +349,7 @@ function unpack_deps(x){
   return x;
 }
 
-function doc_to_dcf(doc){
+export function doc_to_dcf(doc){
   var x = unpack_deps(doc);
   delete x['_id'];
   delete x['_type'];
@@ -366,7 +365,7 @@ function doc_to_dcf(doc){
   }).join("\n") + "\n\n";
 }
 
-function group_package_data(docs){
+export function group_package_data(docs){
   var src = docs.find(x => x['_type'] == 'src');
   var failure = docs.find(x => x['_type'] == 'failure');
   if(!src){
@@ -405,7 +404,7 @@ function group_package_data(docs){
 }
 
 /* Use negative match, because on packages without compiled code Built.Platform is empty */
-function match_macos_arch(platform){
+export function match_macos_arch(platform){
   if(platform.match("arm64|aarch64")){
     return {$not : /x86_64/};
   }
@@ -415,24 +414,6 @@ function match_macos_arch(platform){
   throw `Unknown platform: ${platform}`;
 }
 
-module.exports = {
-  qf: qf,
-  group_package_data: group_package_data,
-  pkgfields: pkgfields,
-  send_extracted_file : send_extracted_file,
-  extract_multi_files: extract_multi_files,
-  get_extracted_file: get_extracted_file,
-  get_extracted_file_multi: get_extracted_file_multi,
-  tar_index_files : tar_index_files,
-  test_if_universe_exists : test_if_universe_exists,
-  get_registry_info : get_registry_info,
-  get_submodule_hash : get_submodule_hash,
-  trigger_rebuild : trigger_rebuild,
-  trigger_recheck : trigger_recheck,
-  get_cran_desc : get_cran_desc,
-  doc_to_dcf : doc_to_dcf,
-  match_macos_arch : match_macos_arch
-};
 
 /* Tests
 get_cran_desc("curl").then(console.log)

--- a/src/tools.js
+++ b/src/tools.js
@@ -3,6 +3,7 @@ import tar from 'tar-stream';
 import gunzip from 'gunzip-maybe';
 import mime from 'mime';
 import {packages, bucket} from '../src/db.js';
+import {Buffer} from "node:buffer";
 
 /* Fields included in PACKAGES indices */
 export const pkgfields = {_id: 1, _type:1, _dependencies: 1, Filesize: '$_filesize', Distro: '$_distro',

--- a/src/tools.js
+++ b/src/tools.js
@@ -2,6 +2,7 @@
 import tar from 'tar-stream';
 import gunzip from 'gunzip-maybe';
 import mime from 'mime';
+import {packages, bucket} from '../src/db.js';
 
 /* Fields included in PACKAGES indices */
 export const pkgfields = {_id: 1, _type:1, _dependencies: 1, Filesize: '$_filesize', Distro: '$_distro',


### PR DESCRIPTION
Things needed to convert:
 - Change `require` to `import` statements
 - We need `import {Buffer}` explicitly in deno2.
 - Remove all uses of the reserved variable name `package`
 - Remove uses of `__dirname`, this is no longer needed 
 - Convert the database into a top-level await module (instead of using global)

One way to test if if we can run it in deno2:

```sh
deno ./bin/www
```